### PR TITLE
Register view location of theme.

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -361,6 +361,20 @@ class Repository implements Arrayable
     }
 
     /**
+     * Register view location of theme.
+     *
+     * @param null $theme
+     */
+    public function registerViewLocation($theme = null)
+    {
+        if (is_null($theme)) {
+            $theme = $this->getCurrent();
+        }
+
+        $this->views->addLocation($this->getPath() . '/' . $theme . '/views');
+    }
+
+    /**
      * Get config from current theme.
      *
      * @param $key


### PR DESCRIPTION
This method allows to use view name without view namespace. Views files dont have to know which theme is activated.

Example view in any module or default resource/views folder.
```
@extends('layouts.master')

@section('content')
    content
@endsection
```
'layouts.master' view will be search in default resource/view/layouts folder and active theme view/layouts folder.

To active this feature, run `Theme::registerViewLocation()` in where you need.

