### PR TITLE
Fix theme url path and asset path.

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -118,7 +118,7 @@ class Repository implements Arrayable
      */
     public function getThemePath($theme)
     {
-        return $this->path."/{$theme}";
+        return $this->getPath() . "/{$theme}";
     }
 
     /**
@@ -368,9 +368,9 @@ class Repository implements Arrayable
      * 
      * @return asset
      */
-    public function asset($asset, $secure = null) 
+    public function asset($asset, $secure = null)
     {
-        return app('url')->asset(config('app.url') . '/themes/' . $this->getCurrent() . '/' . $asset, $secure);
+        return url('themes/' . $this->getCurrent() . '/' . $asset, null, $secure);
     }
     
     /**
@@ -382,7 +382,7 @@ class Repository implements Arrayable
      */
     public function secure_asset($asset)
     {
-        return app('url')->asset(config('app.url') . '/themes/' . $this->getCurrent() . '/' . $asset);
+        return $this->asset($asset, true);
     }
     
     /**


### PR DESCRIPTION
* The asset url base will be get browser path with the url function in Laravel. So, you don't have to specify base url in app.php. It is useful for development and testing cases.
* Fix getting theme path. If theme path isn't set with setPath method, getThemePath method return only theme name.