### PR TITLE
Change directory depth to 1.

### DIFF
--- a/Finder.php
+++ b/Finder.php
@@ -95,7 +95,7 @@ class Finder
                 ->in($path)
                 ->files()
                 ->name(self::FILENAME)
-                ->depth('<= 3')
+                ->depth('== 1')
                 ->followLinks();
 
             foreach ($found as $file) {


### PR DESCRIPTION
The finder will check first level of theme directory. Otherwise it cause a performance problem and <= 3 isn't necessary.
For example, themes directory is XXX and has two directory which are called One, Two. The both of them has themes.json file. The finder tries to find only these json files.